### PR TITLE
modify burn logic

### DIFF
--- a/contracts/ERC3525SlotEnumerableUpgradeable.sol
+++ b/contracts/ERC3525SlotEnumerableUpgradeable.sol
@@ -117,7 +117,7 @@ contract ERC3525SlotEnumerableUpgradeable is ERC3525Upgradeable, IERC3525SlotEnu
         SlotData storage slotData = _allSlots[_allSlotsIndex[slot_]];
         uint256 lastTokenIndex = slotData.slotTokens.length - 1;
         uint256 lastTokenId = slotData.slotTokens[lastTokenIndex];
-        uint256 tokenIndex = slotData.slotTokens[tokenId_];
+        uint256 tokenIndex = _slotTokensIndex[slot_][tokenId_];
 
         slotData.slotTokens[tokenIndex] = lastTokenId;
         _slotTokensIndex[slot_][lastTokenId] = tokenIndex;

--- a/contracts/ERC3525Upgradeable.sol
+++ b/contracts/ERC3525Upgradeable.sol
@@ -350,8 +350,8 @@ abstract contract ERC3525Upgradeable is
         _beforeValueTransfer(owner, address(0), tokenId_, 0, slot, value);
 
         _clearApprovedValues(tokenId_);
-        _removeTokenFromAllTokensEnumeration(tokenId_);
         _removeTokenFromOwnerEnumeration(owner, tokenId_);
+        _removeTokenFromAllTokensEnumeration(tokenId_);
 
         emit TransferValue(tokenId_, 0, value);
         emit Transfer(owner, address(0), tokenId_);
@@ -449,14 +449,14 @@ abstract contract ERC3525Upgradeable is
         uint256 toTokenId_,
         uint256 value_
     ) internal virtual {
-        require(_exists(fromTokenId_), "ERC35255: transfer from nonexistent token");
-        require(_exists(toTokenId_), "ERC35255: transfer to nonexistent token");
+        require(_exists(fromTokenId_), "ERC3525: transfer from nonexistent token");
+        require(_exists(toTokenId_), "ERC3525: transfer to nonexistent token");
 
         TokenData storage fromTokenData = _allTokens[_allTokensIndex[fromTokenId_]];
         TokenData storage toTokenData = _allTokens[_allTokensIndex[toTokenId_]];
 
         require(fromTokenData.balance >= value_, "ERC3525: transfer amount exceeds balance");
-        require(fromTokenData.slot == toTokenData.slot, "ERC3535: transfer to token with different slot");
+        require(fromTokenData.slot == toTokenData.slot, "ERC3525: transfer to token with different slot");
 
         _beforeValueTransfer(
             fromTokenData.owner,


### PR DESCRIPTION
- if  doing `_removeTokenFromAllTokensEnumeration(tokenId_);` first, it will replace the owner whose token Id index is 0 to address(0) while doing `_removeTokenFromOwnerEnumeration(owner, tokenId_);`
- in `_removeTokenFromSlotEnumeration(uint256 slot_, uint256 tokenId_)` function from ERC3525SlotEnumerableUpgradeable.sol, tokenIndex should be `_slotTokensIndex[slot_][tokenId_]`
- correct some typo of revert messages